### PR TITLE
Fix broken client spec

### DIFF
--- a/lib/ridley-connectors.rb
+++ b/lib/ridley-connectors.rb
@@ -3,6 +3,7 @@ require 'celluloid/io'
 require 'ridley'
 
 module Ridley
+  require_relative 'ridley-connectors/client'
   require_relative 'ridley-connectors/host_commander'
   require_relative 'ridley-connectors/host_connector'
   require_relative 'ridley-connectors/chef_objects/node_object'

--- a/lib/ridley-connectors/client.rb
+++ b/lib/ridley-connectors/client.rb
@@ -39,15 +39,16 @@ module Ridley
     #
     # @raise [Errors::ClientKeyFileNotFoundOrInvalid] if the option for :client_key does not contain
     #   a file path pointing to a readable client key, or is a string containing a valid key
+    alias_method :old_initialize, :initialize
     def initialize(options = {})
-      super
+      old_initialize(options)
       @options = options.reverse_merge(
         ssh: Hash.new,
         winrm: Hash.new,
       ).deep_symbolize_keys
 
-      @ssh              = @options[:ssh]
-      @winrm            = @options[:winrm]
-    end    
+      @ssh   = @options[:ssh]
+      @winrm = @options[:winrm]
+    end
   end
 end


### PR DESCRIPTION
- Inheritance is not the same as opening the class up and redefining initialize
- Actually require the modified client file
