### PR TITLE
bump and prepare for a 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.1.2.0
+
+* Bumping internal dependency on Ridley to at least 2.4.2
+
 ## v.1.1.0
 
 * [#2](https://github.com/RiotGames/ridley-connectors/pull/2) Copying an encrypted data bag should not expose the secret

--- a/lib/ridley-connectors/version.rb
+++ b/lib/ridley-connectors/version.rb
@@ -1,5 +1,5 @@
 module Ridley
   module Connectors
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/ridley-connectors.gemspec
+++ b/ridley-connectors.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid', '~> 0.15'
   s.add_dependency 'celluloid-io', '~> 0.15'
   s.add_dependency 'net-ssh'
-  s.add_dependency 'ridley', '~> 2.1.0'
+  s.add_dependency 'ridley', '~> 2.4.2'
   s.add_dependency 'winrm', '~> 1.1.0'
 
   s.add_development_dependency 'buff-ruby_engine', '~> 0.1'


### PR DESCRIPTION
Making a pull request for this because its a large jump in Ridley versions and worth being transparent about.
