### PR TITLE
Hash#reverse_merge checks "set or not set", not "nil or not nil". 

### DIFF
--- a/lib/ridley-connectors/host_commander.rb
+++ b/lib/ridley-connectors/host_commander.rb
@@ -170,7 +170,8 @@ module Ridley
     #
     # @return [HostConnector::SSH, HostConnector::WinRM]
     def connector_for(host, options = {})
-      options = options.reverse_merge(ssh: Hash.new, winrm: Hash.new)
+      options[:ssh]          ||= Hash.new
+      options[:winrm]        ||= Hash.new
       options[:ssh][:port]   ||= HostConnector::SSH::DEFAULT_PORT
       options[:winrm][:port] ||= HostConnector::WinRM::DEFAULT_PORT
 


### PR DESCRIPTION
Explicit nils passed in cause undefined method [] for nil.

This also adds a couple tests that were missing for connector_for.
