### PR TITLE
Issue #12 - Support ssh gateways.

### DIFF
--- a/lib/ridley-connectors/host_connector/ssh.rb
+++ b/lib/ridley-connectors/host_connector/ssh.rb
@@ -1,4 +1,5 @@
 require 'net/ssh'
+require 'net/ssh/gateway'
 
 module Ridley
   module HostConnector
@@ -6,7 +7,8 @@ module Ridley
       DEFAULT_PORT       = 22
       EMBEDDED_RUBY_PATH = '/opt/chef/embedded/bin/ruby'.freeze
 
-      # Execute a shell command on a node
+      # Execute a shell command on a node using ssh. If the gateway option is present then
+      # execute the command through the gateway.
       #
       # @param [String] host
       #   the host to perform the action on
@@ -18,6 +20,7 @@ module Ridley
       #   * :keys (Array, String) an array of key(s) to authenticate the ssh user with instead of a password
       #   * :timeout (Float) timeout value for SSH bootstrap (5.0)
       #   * :sudo (Boolean) run as sudo
+      #   * :gateway (String) user@host:port
       #
       # @return [HostConnector::Response]
       def run(host, command, options = {})
@@ -31,7 +34,7 @@ module Ridley
             log.info "Running SSH command: '#{command}' on: '#{host}' as: '#{options[:ssh][:user]}'"
 
             defer {
-              Net::SSH.start(host, options[:ssh][:user], options[:ssh].slice(*Net::SSH::VALID_OPTIONS)) do |ssh|
+              ssh(host, options) do |ssh|
                 ssh.open_channel do |channel|
                   if options[:sudo]
                     channel.request_pty do |channel, success|
@@ -181,7 +184,66 @@ module Ridley
         run(host, CommandContext::UnixUninstall.command(options), options)
       end
 
+      # Checks to see if the given port is open for TCP connections
+      # on the given host. If a gateway is provided in the ssh
+      # options, then return true if we can connect to the gateway host.
+      # If no gateway config is found then just verify we can connect to
+      # the destination host.
+      #
+      # @param [String] host
+      #   the host to attempt to connect to
+      # @option options [Hash] :ssh
+      #   * :gateway (String) user@host:port
+      #   * :timeout (Float) timeout value for SSH
+      #   * :port (Fixnum) the SSH port
+      # @return [Boolean]
+      def connector_port_open?(host, options = {})
+        options[:ssh]          ||= Hash.new
+        options[:ssh][:port]   ||= HostConnector::SSH::DEFAULT_PORT
+
+        if options[:ssh][:gateway]
+          gw_host, gw_port, _ = gateway(options)
+          log.info("host: #{gw_host}, port: #{gw_port}")
+          port_open?(gw_host, gw_port, options[:ssh][:timeout])
+        else
+          port_open?(host, options[:ssh][:port], options[:ssh][:timeout])
+        end
+      end
+
       private
+
+        def gateway(options)
+          options[:ssh] ||= Hash.new
+
+          if options[:ssh][:gateway]
+            gw_host, gw_user = options[:ssh][:gateway].split("@").reverse
+            gw_host, gw_port = gw_host.split(":")
+            gw_port ||= HostConnector::SSH::DEFAULT_PORT
+            [gw_host, gw_port, gw_user]
+          else
+            [nil, nil, nil]
+          end
+
+        end
+
+        # Open an SSH connection either directly or through a gateway.
+        def ssh(host, options, &block)
+          if options[:ssh][:gateway]
+            gw_host, gw_port, gw_user = gateway(options)
+            gateway = Net::SSH::Gateway.new(gw_host, gw_user, {:port => gw_port})
+            begin
+              gateway.ssh(host, options[:ssh][:user], options[:ssh].slice(*Net::SSH::VALID_OPTIONS)) do |ssh|
+                yield ssh
+              end
+            ensure
+              gateway.shutdown!
+            end
+          else
+            Net::SSH.start(host, options[:ssh][:user], options[:ssh].slice(*Net::SSH::VALID_OPTIONS)) do |ssh|
+              yield ssh
+            end
+          end
+        end
 
         def channel_exec(channel, command, host, response)
           channel.exec(command) do |ch, success|

--- a/lib/ridley-connectors/host_connector/winrm.rb
+++ b/lib/ridley-connectors/host_connector/winrm.rb
@@ -207,6 +207,23 @@ module Ridley
         run(host, CommandContext::WindowsUninstall.command(options), options)
       end
 
+      # Checks to see if the given port is open for TCP connections
+      # on the given host.
+      #
+      # @param [String] host
+      #   the host to attempt to connect to
+      # @option options [Hash] :winrm
+      #   * port (Fixnum) the winrm port to connect to
+      #
+      # @return [Boolean]
+      def connector_port_open?(host, options = {})
+        options[:winrm]        ||= Hash.new
+        options[:winrm][:port] ||= HostConnector::WinRM::DEFAULT_PORT
+
+        port_open?(host, options[:winrm][:port])
+      end
+
+
       private
 
         # @param [String] host

--- a/ridley-connectors.gemspec
+++ b/ridley-connectors.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid', '~> 0.15'
   s.add_dependency 'celluloid-io', '~> 0.15'
   s.add_dependency 'net-ssh'
+  s.add_dependency 'net-ssh-gateway'
   s.add_dependency 'ridley', '~> 2.4.2'
   s.add_dependency 'winrm', '~> 1.1.0'
 

--- a/spec/unit/ridley-connectors/host_commander_spec.rb
+++ b/spec/unit/ridley-connectors/host_commander_spec.rb
@@ -12,8 +12,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(false)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(true)
       end
 
       it "sends a #run message to the ssh host connector" do
@@ -24,8 +24,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(true)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(false)
       end
 
       it "sends a #run message to the ssh host connector" do
@@ -43,8 +43,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(false)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(true)
       end
 
       it "sends a #bootstrap message to the ssh host connector" do
@@ -56,8 +56,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(true)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(false)
       end
 
       it "sends a #bootstrap message to the winrm host connector" do
@@ -75,8 +75,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(false)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(true)
       end
 
       it "sends a #chef_client message to the ssh host connector" do
@@ -88,8 +88,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(true)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(false)
       end
 
       it "sends a #chef_client message to the ssh host connector" do
@@ -108,8 +108,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(false)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(true)
       end
 
       it "sends a #put_secret message to the ssh host connector" do
@@ -121,8 +121,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(true)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(false)
       end
 
       it "sends a #put_secret message to the ssh host connector" do
@@ -141,8 +141,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(false)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(true)
       end
 
       it "sends a #ruby_script message to the ssh host connector" do
@@ -154,8 +154,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.send(:winrm).stub(:connector_port_open?).with(host, options).and_return(true)
+        subject.send(:ssh).stub(:connector_port_open?).with(host, options).and_return(false)
       end
 
       it "sends a #ruby_script message to the ssh host connector" do
@@ -168,22 +168,14 @@ describe Ridley::HostCommander do
 
   describe "#connector_for" do
     it "should return winrm if winrm is open" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(true)
-      subject.should_receive(:winrm)
-      subject.connector_for(host)
-    end
-    
-    it "should return winrm if winrm is open" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(false)
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::SSH::DEFAULT_PORT, nil).and_return(true)
-      subject.should_receive(:ssh)
-      subject.connector_for(host)
+      subject.send(:winrm).stub(:connector_port_open?).with(host, {}).and_return(true)
+      subject.connector_for(host).class.should == Ridley::HostConnector::WinRM
     end
 
-    it "should still set the default ports if an explicit nil is passed in" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(true)
-      subject.should_receive(:winrm)
-      subject.connector_for(host, winrm: nil, ssh: nil)
+    it "should return ssh if ssh is open" do
+      subject.send(:winrm).stub(:connector_port_open?).with(host, {}).and_return(false)
+      subject.send(:ssh).stub(:connector_port_open?).with(host, {}).and_return(true)
+      subject.connector_for(host).class.should == Ridley::HostConnector::SSH
     end
   end
 end

--- a/spec/unit/ridley-connectors/host_connector/ssh_spec.rb
+++ b/spec/unit/ridley-connectors/host_connector/ssh_spec.rb
@@ -16,6 +16,34 @@ describe Ridley::HostConnector::SSH do
     }
   end
 
+  describe "#run" do
+    let(:ssh_user) { 'ssh_user' }
+
+    context "when a gateway is given" do
+      let(:gw_host) { "bar.com" }
+      let(:gw_user) { "foo" }
+      let(:gw_port) { "1234" }
+      let(:gateway) { double(Net::SSH::Gateway) }
+
+      before do
+        Net::SSH::Gateway.stub(:new).with(gw_host, gw_user, {:port => gw_port}).and_return(gateway)
+      end
+
+      it "should connect to the gateway with Net::SSH::Gateway and then to the destination host via the gateway" do
+        gateway.should_receive(:ssh).with(host, ssh_user, anything).ordered
+        gateway.should_receive(:shutdown!).ordered
+        subject.run(host, "some_command", ssh: { user: ssh_user, gateway: 'foo@bar.com:1234' })
+      end
+    end
+
+    context "when a gateway is not given" do
+      it "should use Net::SSH to connect to the destination host" do
+        Net::SSH.should_receive(:start).with(host, ssh_user, {:paranoid=>false, :port=>"1234", :user=>"ssh_user"})
+        subject.run(host, "some_command", ssh: { user: ssh_user, port: "1234" })
+      end
+    end
+  end
+
   describe "#bootstrap" do
     let(:bootstrap_context) { Ridley::BootstrapContext::Unix.new(options) }
 
@@ -66,4 +94,33 @@ describe Ridley::HostConnector::SSH do
       connector.ruby_script(host, command_lines, options)
     end
   end
+
+  describe "#connector_port_open?" do
+    context "when there are no ssh options specified" do
+      it "should try to connect to the host on the defaul ssh port" do
+        subject.should_receive(:port_open?).with(host, Ridley::HostConnector::SSH::DEFAULT_PORT, nil)
+        subject.connector_port_open?(host, {})
+      end
+    end
+
+    context "when the port is specified" do
+      it "should try to connecto to the host on the given port" do
+        subject.should_receive(:port_open?).with(host, 1234, nil)
+        subject.connector_port_open?(host, ssh: {port: 1234} )
+      end
+    end
+
+    context "when the gateway is given" do
+      it "should try to connect to the gateway host" do
+        subject.should_receive(:port_open?).with("bar.com", "1234", nil)
+        subject.connector_port_open?(host, ssh: {gateway: 'foo@bar.com:1234'} )
+      end
+
+      it "should use the timeout from the ssh settings" do
+        subject.should_receive(:port_open?).with("bar.com", "1234", 12)
+        subject.connector_port_open?(host, ssh: {timeout: 12, gateway: 'foo@bar.com:1234'} )
+      end
+    end
+  end
+
 end

--- a/spec/unit/ridley-connectors/host_connector/winrm_spec.rb
+++ b/spec/unit/ridley-connectors/host_connector/winrm_spec.rb
@@ -172,4 +172,20 @@ describe Ridley::HostConnector::WinRM do
       ruby_script
     end
   end
+
+  describe "#connector_port_open?" do
+    context "when no winrm options are specified" do
+      it "should connect using the default winrm port" do
+        subject.should_receive(:port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT)
+        subject.connector_port_open?(host, {})
+      end
+    end
+
+    context "when winrm options are given" do
+      it "should use the winrm port" do
+        subject.should_receive(:port_open?).with(host, 1234)
+        subject.connector_port_open?(host, winrm: {port: 1234})
+      end
+    end
+  end
 end


### PR DESCRIPTION
Looking for feedback...

This commit provides support for connecting to the destination host via an SSH gateway.
- connector_port_open? implementation for winrm and ssh
- the ssh implementation checks if it can connect to the gateway if the gateway is given. If
  it is not given then connect directly to the destination.
- host_commander#connector_for now calls the connector_port_open? for winrm and then ssh.
- port_open? moved to host_connector so it could be called from the winrm and ssh host connectors.
- ssh connector's run method now creates a gateway connection if the gateway value is in the :ssh options.
