### PR TITLE
Add retries to ssh and winrm connections.  (Default 3)

### DIFF
--- a/lib/ridley-connectors/version.rb
+++ b/lib/ridley-connectors/version.rb
@@ -1,5 +1,5 @@
 module Ridley
   module Connectors
-    VERSION = '1.6.0'
+    VERSION = '1.6.1'
   end
 end

--- a/spec/unit/ridley-connectors/host_commander_spec.rb
+++ b/spec/unit/ridley-connectors/host_commander_spec.rb
@@ -7,13 +7,13 @@ describe Ridley::HostCommander do
   describe "#run" do
     let(:command) { "ls" }
     let(:options) do
-      { ssh: { port: 22 }, winrm: { port: 5985 } }
+      { ssh: { port: 22, timeout: 3 }, winrm: { port: 5985, timeout: 3 }, retries: 3 }
     end
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(true)
       end
 
       it "sends a #run message to the ssh host connector" do
@@ -24,8 +24,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(false)
       end
 
       it "sends a #run message to the ssh host connector" do
@@ -38,13 +38,13 @@ describe Ridley::HostCommander do
 
   describe "#bootstrap" do
     let(:options) do
-      { ssh: { port: 22 }, winrm: { port: 5985 } }
+      { ssh: { port: 22, timeout: 3 }, winrm: { port: 5985, timeout: 3 }, retries: 3 }
     end
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(true)
       end
 
       it "sends a #bootstrap message to the ssh host connector" do
@@ -56,8 +56,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(false)
       end
 
       it "sends a #bootstrap message to the winrm host connector" do
@@ -70,13 +70,13 @@ describe Ridley::HostCommander do
 
   describe "#chef_client" do
     let(:options) do
-      { ssh: { port: 22 }, winrm: { port: 5985 } }
+      { ssh: { port: 22, timeout: 3 }, winrm: { port: 5985, timeout: 3 }, retries: 3 }
     end
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(true)
       end
 
       it "sends a #chef_client message to the ssh host connector" do
@@ -88,8 +88,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(false)
       end
 
       it "sends a #chef_client message to the ssh host connector" do
@@ -103,13 +103,13 @@ describe Ridley::HostCommander do
   describe "#put_secret" do
     let(:secret) { "something_secret" }
     let(:options) do
-      { ssh: { port: 22 }, winrm: { port: 5985 } }
+      { ssh: { port: 22, timeout: 3 }, winrm: { port: 5985, timeout: 3 }, retries: 3 }
     end
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(true)
       end
 
       it "sends a #put_secret message to the ssh host connector" do
@@ -121,8 +121,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(false)
       end
 
       it "sends a #put_secret message to the ssh host connector" do
@@ -136,13 +136,13 @@ describe Ridley::HostCommander do
   describe "#ruby_script" do
     let(:command_lines) { ["line one"] }
     let(:options) do
-      { ssh: { port: 22 }, winrm: { port: 5985 } }
+      { ssh: { port: 22, timeout: 3 }, winrm: { port: 5985, timeout: 3 }, retries: 3 }
     end
 
     context "when communicating to a unix node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(false)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(true)
       end
 
       it "sends a #ruby_script message to the ssh host connector" do
@@ -154,8 +154,8 @@ describe Ridley::HostCommander do
 
     context "when communicating to a windows node" do
       before do
-        subject.stub(:connector_port_open?).with(host, options[:winrm][:port]).and_return(true)
-        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything).and_return(false)
+        subject.stub(:connector_port_open?).with(host, options[:winrm][:port], anything, anything).and_return(true)
+        subject.stub(:connector_port_open?).with(host, options[:ssh][:port], anything, anything).and_return(false)
       end
 
       it "sends a #ruby_script message to the ssh host connector" do
@@ -168,20 +168,20 @@ describe Ridley::HostCommander do
 
   describe "#connector_for" do
     it "should return winrm if winrm is open" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(true)
+      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT, anything, anything).and_return(true)
       subject.should_receive(:winrm)
       subject.connector_for(host)
     end
     
-    it "should return winrm if winrm is open" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(false)
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::SSH::DEFAULT_PORT, nil).and_return(true)
+    it "should return ssh if winrm is closed" do
+      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT, anything, anything).and_return(false)
+      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::SSH::DEFAULT_PORT, anything, anything).and_return(true)
       subject.should_receive(:ssh)
       subject.connector_for(host)
     end
 
     it "should still set the default ports if an explicit nil is passed in" do
-      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT).and_return(true)
+      subject.stub(:connector_port_open?).with(host, Ridley::HostConnector::WinRM::DEFAULT_PORT, anything, anything).and_return(true)
       subject.should_receive(:winrm)
       subject.connector_for(host, winrm: nil, ssh: nil)
     end


### PR DESCRIPTION
This adds logic to do retries to connector_port_open?  Defaults to 3 retries, but still uses existing timeout per protocol.  Might want to default connection timeout to something lower if you don't want the overhead of the timeout being retries x timeout.
