### PR TITLE
Scripts and Bootstrappers working again

### DIFF
--- a/lib/ridley-connectors.rb
+++ b/lib/ridley-connectors.rb
@@ -3,10 +3,23 @@ require 'celluloid/io'
 require 'ridley'
 
 module Ridley
-  class << self
-    # @return [Pathname]
-    def scripts
-      root.join('scripts')
+  module Connectors
+    class << self
+
+      # @return [Pathname]
+      def root
+        @root ||= Pathname.new(File.expand_path('../', File.dirname(__FILE__)))
+      end
+
+      # @return [Pathname]
+      def scripts
+        root.join('scripts')
+      end
+
+      # @return [Pathname]
+      def bootstrappers
+        root.join('bootstrappers')
+      end
     end
   end
 

--- a/lib/ridley-connectors/bootstrap_context.rb
+++ b/lib/ridley-connectors/bootstrap_context.rb
@@ -68,7 +68,7 @@ module Ridley
 
       # @return [Pathname]
       def templates_path
-        Ridley.root.join('bootstrappers')
+        Ridley::Connectors.bootstrappers
       end
 
       # @return [String]

--- a/lib/ridley-connectors/command_context.rb
+++ b/lib/ridley-connectors/command_context.rb
@@ -28,7 +28,7 @@ module Ridley
         # @return [Pathname]
         def template_file(filename = nil)
           return @template_file if filename.nil?
-          @template_file = Ridley.scripts.join("#{filename}.erb")
+          @template_file = Ridley::Connectors.scripts.join("#{filename}.erb")
         end
       end
 

--- a/ridley-connectors.gemspec
+++ b/ridley-connectors.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io', '~> 0.16.0.pre'
   s.add_dependency 'erubis'
   s.add_dependency 'net-ssh'
-  s.add_dependency 'ridley',       '~> 3.0'
+  s.add_dependency 'ridley',       '~> 3.1'
   s.add_dependency 'winrm',        '~> 1.1.0'
 
   s.add_development_dependency 'buff-ruby_engine', '~> 0.1'


### PR DESCRIPTION
I think my brain melted down while doing the work on https://github.com/RiotGames/ridley/pull/264, and I missed the opportunity in this gem to take the newest release of Ridley with that work in it.

I also needed to fix some of the basic module `root` type functions to reflect the change in paths from `ridley/...` to `ridley-connectors/...`

Basically,

```
Ridley.root #=> #<Pathname:/Users/kallan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ridley-3.1.0>
Ridley::Connectors.root #=> #<Pathname:/Users/kallan/src/ridley-connectors>
Ridley::Connectors.scripts #=> #<Pathname:/Users/kallan/src/ridley-connectors/scripts>
Ridley::Connectors.bootstrappers #=> #<Pathname:/Users/kallan/src/ridley-connectors/bootstrappers>
```
