### PR TITLE
fetch connector from environment

### DIFF
--- a/lib/ridley-connectors/host_commander.rb
+++ b/lib/ridley-connectors/host_commander.rb
@@ -225,7 +225,7 @@ module Ridley
     #
     # @return [HostConnector::SSH, HostConnector::WinRM, NilClass]
     def connector_for(host, options = {})
-      connector = options[:connector].to_s
+      connector = options[:connector].to_s || ENV['RIDLEY_CONNECTOR']
 
       if !VALID_CONNECTORS.include?(connector)
         log.debug { "Connector '#{connector}' is not one of #{VALID_CONNECTORS}. Determining connector..." }


### PR DESCRIPTION
Sometime it fails to determine correct connector. For linux machine its trying to run WinRM command, as in screenshot attached.

<img width="1360" alt="screen shot 2015-10-12 at 11 11 05 am" src="https://cloud.githubusercontent.com/assets/1409648/10422117/60505164-70d3-11e5-9c49-143909637eb8.png">
